### PR TITLE
JCF: to build with gcc 13.2.0, cstdint needs to be included for unsig…

### DIFF
--- a/test/apps/test-pcie-axil.cxx
+++ b/test/apps/test-pcie-axil.cxx
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <iomanip>
 #include <vector>
-
+#include <cstdint>
 
 /* /sys/bus/pci/devices/0000:<bus>:<dev>.<func>/resource<bar#> */
 #define get_syspath_bar_mmap(s, bus,dev,func,bar) \


### PR DESCRIPTION
…ned integers